### PR TITLE
Updating global styles so prefer-dark-mode has no effect

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,77 +1,39 @@
+/**
+  * @file Global styles
+  * we're setting up this site to be "dark mode only", so 
+  * it won't be affected by user setting "prefers-dark-mode"
+  */
 :root {
-  --max-width: 1100px;
-  --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
-    'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
-    'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
+  --foreground-rgb: 255, 255, 255;
+  --background-start-rgb: 0, 0, 0;
+  --background-end-rgb: 0, 0, 0;
 
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-
-  --primary-glow: conic-gradient(
-    from 180deg at 50% 50%,
-    #16abff33 0deg,
-    #0885ff33 55deg,
-    #54d6ff33 120deg,
-    #0071ff33 160deg,
-    transparent 360deg
-  );
-  --secondary-glow: radial-gradient(
-    rgba(255, 255, 255, 1),
-    rgba(255, 255, 255, 0)
+  --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
+  --secondary-glow: linear-gradient(
+    to bottom right,
+    rgba(1, 65, 255, 0),
+    rgba(1, 65, 255, 0),
+    rgba(1, 65, 255, 0.3)
   );
 
-  --tile-start-rgb: 239, 245, 249;
-  --tile-end-rgb: 228, 232, 233;
+  --tile-start-rgb: 2, 13, 46;
+  --tile-end-rgb: 2, 5, 19;
   --tile-border: conic-gradient(
-    #00000080,
-    #00000040,
-    #00000030,
-    #00000020,
-    #00000010,
-    #00000010,
-    #00000080
+    #ffffff80,
+    #ffffff40,
+    #ffffff30,
+    #ffffff20,
+    #ffffff10,
+    #ffffff10,
+    #ffffff80
   );
 
-  --callout-rgb: 238, 240, 241;
-  --callout-border-rgb: 172, 175, 176;
-  --card-rgb: 180, 185, 188;
-  --card-border-rgb: 131, 134, 135;
+  --callout-rgb: 20, 20, 20;
+  --callout-border-rgb: 108, 108, 108;
+  --card-rgb: 100, 100, 100;
+  --card-border-rgb: 200, 200, 200;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-
-    --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
-    --secondary-glow: linear-gradient(
-      to bottom right,
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0.3)
-    );
-
-    --tile-start-rgb: 2, 13, 46;
-    --tile-end-rgb: 2, 5, 19;
-    --tile-border: conic-gradient(
-      #ffffff80,
-      #ffffff40,
-      #ffffff30,
-      #ffffff20,
-      #ffffff10,
-      #ffffff10,
-      #ffffff80
-    );
-
-    --callout-rgb: 20, 20, 20;
-    --callout-border-rgb: 108, 108, 108;
-    --card-rgb: 100, 100, 100;
-    --card-border-rgb: 200, 200, 200;
-  }
-}
 
 * {
   box-sizing: border-box;

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,19 +1,26 @@
 import { createTheme } from '@mui/material/styles'
-import ListItemText from '@mui/material/ListItemText';
+
 export const theme = createTheme({
   components: {
+    MuiSvgIcon: {
+      styleOverrides: {
+        root: {
+          color: process.env.NEXT_PUBLIC_THEME_DARK,
+        },
+      },
+    },
     MuiPaper: {
       styleOverrides: {
         root: {
-          backgroundColor: process.env.NEXT_PUBLIC_THEME_DARK,
-          color: "white",
+          backgroundColor: process.env.NEXT_PUBLIC_THEME_PRIMARY,
+          color: process.env.NEXT_PUBLIC_THEME_DARK,
         },
       },
     },
     MuiAppBar: {
       styleOverrides: {
         root: {
-          backgroundColor: process.env.NEXT_PUBLIC_THEME_DARK,
+          backgroundColor: process.env.NEXT_PUBLIC_THEME_PRIMARY,
         },
       },
     }
@@ -23,13 +30,18 @@ export const theme = createTheme({
     h1: {
       fontSize: "2rem",
       marginBottom: "1rem",
+      color: process.env.NEXT_PUBLIC_THEME_LIGHT,
+    },
+    h6: {
+      color: process.env.NEXT_PUBLIC_THEME_TERTIARY,
     },
     body1: {
-      // marginBottom: "1.5rem",
+      color: process.env.NEXT_PUBLIC_THEME_DARK,
     },
     body2: {
       marginBottom: "1rem",
       fontSize: "1.2rem",
+      color: process.env.NEXT_PUBLIC_THEME_LIGHT,
     },
   },
   palette: {


### PR DESCRIPTION
Updating global styles so that the user setting "prefer-dark-mode" has no effect on the overall styling of the application. This might be something to consider changing back to later for accessibility reasons.